### PR TITLE
Update copyrights to 2025

### DIFF
--- a/src/Footer.svelte
+++ b/src/Footer.svelte
@@ -64,7 +64,7 @@
     <hr class="my-6 border-gray-200 sm:mx-auto dark:border-gray-700 lg:my-8" />
     <div class="sm:flex sm:items-center sm:justify-between">
       <span class="text-sm text-gray-500 dark:text-gray-400"
-        >© 2024 <a href="https://flowbite.com/" class="hover:underline"
+        >© 2025 <a class="hover:underline"
           >H1EMU</a
         >. All Rights Reserved. H1Emu is not affiliated with H1Z1.com, H1Z1:
         Just Survive or Daybreak Game Company LLC, H1Z1 and the H1Z1 logo are


### PR DESCRIPTION
Update the copyright year in the footer and remove the flowbite href.

* Update the copyright year from 2024 to 2025 in the footer text.
* Remove the `href` attribute from the `a` tag with the text "H1EMU". 

